### PR TITLE
Updating assembly version to match formatting filter

### DIFF
--- a/KavitaEmail/KavitaEmail.csproj
+++ b/KavitaEmail/KavitaEmail.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <RootNamespace>Skeleton</RootNamespace>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
+        <AssemblyVersion>0.1.0.0</AssemblyVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Versioning action expects X.X.X.X format for assembly version, previously using X.X.X.