### PR TITLE
Use correct property for network credential

### DIFF
--- a/KavitaEmail/Services/EmailService.cs
+++ b/KavitaEmail/Services/EmailService.cs
@@ -111,7 +111,7 @@ public class EmailService : IEmailService
             EnableSsl = _smtpConfig.EnableSsl,
             DeliveryMethod = SmtpDeliveryMethod.Network,
             UseDefaultCredentials = _smtpConfig.UseDefaultCredentials,
-            Credentials = new NetworkCredential(_smtpConfig.SenderAddress, _smtpConfig.Password),
+            Credentials = new NetworkCredential(_smtpConfig.UserName, _smtpConfig.Password),
             Timeout = 20000
         };
 


### PR DESCRIPTION
# Fixes
- Fixed: Fixed a typo where Email service was using SenderAddress instead of Username for authentication