### PR TITLE
Customizable Size Limit & More Logging

### DIFF
--- a/KavitaEmail/Controllers/CommonController.cs
+++ b/KavitaEmail/Controllers/CommonController.cs
@@ -25,6 +25,9 @@ public class CommonController : BaseApiController
     [HttpGet("test")]
     public ActionResult<bool> Test()
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[test] Request came in from {InstallId} on version {Version}", installId, version);
         _logger.LogInformation("Test called and validated");
         return Ok(true);
     }
@@ -36,7 +39,10 @@ public class CommonController : BaseApiController
     [HttpGet("reachable")]
     public async Task<ActionResult<bool>> CanReachServer(string host)
     {
-        _logger.LogInformation("Can Reach Server triggered");
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[reachable] Request came in from {InstallId} on version {Version}", installId, version);
+        
         var apiUrl = Request.Scheme + "://" + host + Request.PathBase + "/api/";
         FlurlHttp.ConfigureClient(apiUrl, cli =>
             cli.Settings.HttpClientFactory = new UntrustedCertClientFactory());

--- a/KavitaEmail/Controllers/EmailController.cs
+++ b/KavitaEmail/Controllers/EmailController.cs
@@ -33,12 +33,18 @@ public class EmailController : BaseApiController
     [HttpGet("test")]
     public ActionResult<bool> Test()
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[test] Request came in from {InstallId} on version {Version}", installId, version);
         return Ok(true);
     }
 
     [HttpPost("confirm")]
     public async Task<ActionResult> SendConfirmationEmail(ConfirmationEmailDto dto)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[email-confirm] Request came in from {InstallId} on version {Version}", installId, version);
         if (!await _validationService.ValidateInstall(dto.InstallId))
         {
             _logger.LogError("An installID {InstallId} was not valid, request rejected for confirmation email", dto.InstallId);
@@ -51,6 +57,9 @@ public class EmailController : BaseApiController
     [HttpPost("email-migration")]
     public async Task<ActionResult> SendEmailMigrationEmail(EmailMigrationDto dto)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[email-migration] Request came in from {InstallId} on version {Version}", installId, version);
         if (!await _validationService.ValidateInstall(dto.InstallId)) return BadRequest("Not valid");
         await _emailService.SendEmailMigrationEmail(dto);
         return Ok();
@@ -59,6 +68,9 @@ public class EmailController : BaseApiController
     [HttpPost("email-password-reset")]
     public async Task<ActionResult> SendPasswordResetConfirmation(PasswordResetDto dto)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[email-password-reset] Request came in from {InstallId} on version {Version}", installId, version);
         if (!await _validationService.ValidateInstall(dto.InstallId)) return BadRequest("Not valid");
         _logger.LogInformation("Email Password Reset called");
         await _emailService.SendPasswordResetEmail(dto);
@@ -72,6 +84,9 @@ public class EmailController : BaseApiController
     [HttpGet("reachable")]
     public async Task<ActionResult<bool>> CanReachServer(string host)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[reachable] Request came in from {InstallId} on version {Version}", installId, version);
         var apiUrl = Request.Scheme + "://" + host + Request.PathBase + "/api/";
         FlurlHttp.ConfigureClient(apiUrl, cli =>
             cli.Settings.HttpClientFactory = new UntrustedCertClientFactory());

--- a/KavitaEmail/Controllers/InviteController.cs
+++ b/KavitaEmail/Controllers/InviteController.cs
@@ -29,6 +29,9 @@ public class InviteController : BaseApiController
     [HttpPost("confirm")]
     public async Task<ActionResult> SendConfirmationEmail(ConfirmationEmailDto dto)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[email-confirm] Request came in from {InstallId} on version {Version}", installId, version);
         if (!await _validationService.ValidateInstall(dto.InstallId))
         {
             _logger.LogError("An installID {InstallId} was not valid, request rejected for confirmation email", dto.InstallId);
@@ -41,6 +44,9 @@ public class InviteController : BaseApiController
     [HttpPost("email-migration")]
     public async Task<ActionResult> SendEmailMigrationEmail(EmailMigrationDto dto)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[email-migration] Request came in from {InstallId} on version {Version}", installId, version);
         if (!await _validationService.ValidateInstall(dto.InstallId))
         {
             _logger.LogInformation("InstallId {InstallId} could not be validated against Stat service. Send Email for Migration rejected", dto.EmailAddress);
@@ -53,6 +59,9 @@ public class InviteController : BaseApiController
     [HttpPost("email-password-reset")]
     public async Task<ActionResult> SendPasswordResetConfirmation(PasswordResetDto dto)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[email-password-reset] Request came in from {InstallId} on version {Version}", installId, version);
         if (!await _validationService.ValidateInstall(dto.InstallId))
         {
             _logger.LogInformation("InstallId {InstallId} could not be validated against Stat service. Send Password Reset confirmation rejected", dto.EmailAddress);

--- a/KavitaEmail/Controllers/SendToController.cs
+++ b/KavitaEmail/Controllers/SendToController.cs
@@ -21,7 +21,6 @@ public class SendToController : BaseApiController
     private readonly ILogger<SendToController> _logger;
     private readonly SmtpConfig _smtpConfig;
     private readonly IEmailService _emailService;
-    private const int SizeLimit = 26_214_400;
     private readonly string[] _permittedExtensions = { ".epub", ".pdf" };
     private readonly string _tempPath;
 
@@ -37,7 +36,7 @@ public class SendToController : BaseApiController
     }
 
 
-    [RequestSizeLimit(SizeLimit)]
+    [DisableRequestSizeLimit]
     [HttpPost]
     public async Task<ActionResult<bool>> UploadAndSend(IFormCollection formCollection)
     {
@@ -50,9 +49,9 @@ public class SendToController : BaseApiController
 
         if (formCollection.Files.Count == 0) return BadRequest("Nothing to send to device");
         
-        // // Validate size limit
+        // Validate size limit
         var size = formCollection.Files.Sum(f => f.Length);
-        if (size > SizeLimit) return BadRequest("Files are too large");
+        if (size > _smtpConfig.SizeLimit) return BadRequest("Files are too large");
         
         // Validate correct extension
         if (!formCollection.Files.All(f =>

--- a/KavitaEmail/Controllers/SendToController.cs
+++ b/KavitaEmail/Controllers/SendToController.cs
@@ -40,6 +40,9 @@ public class SendToController : BaseApiController
     [HttpPost]
     public async Task<ActionResult<bool>> UploadAndSend(IFormCollection formCollection)
     {
+        Request.Headers.TryGetValue("x-kavita-installId", out var installId);
+        Request.Headers.TryGetValue("x-kavita-version", out var version);
+        _logger.LogInformation("[send-to] Request came in from {InstallId} on version {Version}", installId, version);
         if (!_smtpConfig.AllowSendTo) return BadRequest("This API is not enabled");
         
         _logger.LogInformation("Received a Send to request for {FileCount} files", formCollection.Files.Count);

--- a/KavitaEmail/DTOs/SMTPConfig.cs
+++ b/KavitaEmail/DTOs/SMTPConfig.cs
@@ -16,4 +16,8 @@ public class SmtpConfig
     /// If enabled, this allows Kavita to upload files (temporarily) and send the files as attachments
     /// </summary>
     public bool AllowSendTo { get; set; }
+    /// <summary>
+    /// Limit in bytes for allowing files to be added as attachments. Defaults to 25MB
+    /// </summary>
+    public int SizeLimit { get; set; } = 26_214_400;
 }

--- a/KavitaEmail/Startup.cs
+++ b/KavitaEmail/Startup.cs
@@ -37,8 +37,7 @@ namespace Skeleton
             services.AddControllers();
             services.Configure<ForwardedHeadersOptions>(options =>
             {
-                options.ForwardedHeaders =
-                    ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                options.ForwardedHeaders = ForwardedHeaders.All;
             });
             services.AddCors();
             services.AddIdentityServices(_config);

--- a/KavitaEmail/config/appsettings.json
+++ b/KavitaEmail/config/appsettings.json
@@ -35,6 +35,7 @@
     "EnableSsl": true,
     "UseDefaultCredentials": false,
     "IsBodyHtml": true,
-    "AllowSendTo": true
+    "AllowSendTo": true,
+    "SizeLimit": 26214400
   }
 }


### PR DESCRIPTION
# Changed
- Changed: Users can now configure the size limit for SendTo to values greater than 25MB by using SizeLimit field in SMTP Config.
- Changed: Added logging with Kavita Version and InstalID (represents unique installs) to allow for throughput visualization