### PR TITLE
Fixed templates missing on manual builds.

### DIFF
--- a/KavitaEmail/KavitaEmail.csproj
+++ b/KavitaEmail/KavitaEmail.csproj
@@ -29,7 +29,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="config\temp" />
+        <Folder Include="config\templates" />
+        <Folder Include="config\appsettings.json" />
     </ItemGroup>
 
 </Project>

--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,9 @@ Package()
 
 	  echo "Copying appsettings.json"
     cp ./config/appsettings.json $lOutputFolder/config/appsettings.json
+    
+    echo "Copying templates"
+    cp -a ./config/templates/ $lOutputFolder/config/templates/
 
     echo "Creating tar"
     cd ../$outputFolder/"$runtime"/


### PR DESCRIPTION
# Fixed
- Fixed: Fixed templates not being copied over on manual builds (Fixes #27 )