### PR TITLE
Allow No-Authentication

### DIFF
--- a/KavitaEmail/KavitaEmail.csproj
+++ b/KavitaEmail/KavitaEmail.csproj
@@ -10,19 +10,19 @@
 
     <ItemGroup>
         <PackageReference Include="Flurl.Http" Version="3.2.4" />
-        <PackageReference Include="MailKit" Version="4.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
+        <PackageReference Include="MailKit" Version="4.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.8">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.8" />
         <PackageReference Include="NReco.Logging.File" Version="1.1.6" />
-        <PackageReference Include="Serilog" Version="2.12.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+        <PackageReference Include="Serilog" Version="3.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+        <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/KavitaEmail/Services/EmailService.cs
+++ b/KavitaEmail/Services/EmailService.cs
@@ -182,7 +182,11 @@ public class EmailService : IEmailService
         };
       
         await smtpClient.ConnectAsync(_smtpConfig.Host, _smtpConfig.Port);
-        await smtpClient.AuthenticateAsync(_smtpConfig.UserName, _smtpConfig.Password);
+        if (!string.IsNullOrEmpty(_smtpConfig.UserName) && !string.IsNullOrEmpty(_smtpConfig.Password))
+        {
+            await smtpClient.AuthenticateAsync(_smtpConfig.UserName, _smtpConfig.Password);
+        }
+
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
         try

--- a/KavitaEmail/config/templates/EmailTest.html
+++ b/KavitaEmail/config/templates/EmailTest.html
@@ -199,7 +199,9 @@
 <body width="100%" bgcolor="#F1F1F1" style="margin: 0; mso-line-height-rule: exactly;">
 	<center style="width: 100%; background: #F1F1F1; text-align: left;">
 		<!-- Visually Hidden Preheader Text : BEGIN -->
-		<div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family: sans-serif;"> You have been invited to {{InvitingUser}}'s Kavita instance. Click the button to accept the invite. </div>
+		<div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family: sans-serif;"> 
+			This is a Test Email 
+		</div>
 		<!-- Visually Hidden Preheader Text : END -->
 		<!--
             Set the email width. Defined in two places:

--- a/KavitaEmail/config/templates/SendToDevice.html
+++ b/KavitaEmail/config/templates/SendToDevice.html
@@ -199,7 +199,7 @@
 <body width="100%" bgcolor="#F1F1F1" style="margin: 0; mso-line-height-rule: exactly;">
 	<center style="width: 100%; background: #F1F1F1; text-align: left;">
 		<!-- Visually Hidden Preheader Text : BEGIN -->
-		<div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family: sans-serif;"> You have been invited to {{InvitingUser}}'s Kavita instance. Click the button to accept the invite. </div>
+		<div style="display:none;font-size:1px;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;font-family: sans-serif;"> You've been sent a file from Kavita! </div>
 		<!-- Visually Hidden Preheader Text : END -->
 		<!--
             Set the email width. Defined in two places:


### PR DESCRIPTION
# Changed
- Changed: If no username/password is set, don't try to authenticate (Fixes #43 )
- Changed: Preheader text for Send to Device now shows the correct message